### PR TITLE
Update of site for FHA 2024

### DIFF
--- a/_events/FHA 2024.md
+++ b/_events/FHA 2024.md
@@ -9,6 +9,7 @@ description: ""
 <p>Join us at the Singapore Pavilion, where our companies look forward to forging collaborations, establishing distribution channels, and building valuable partnerships in the global food industry.</p>
 
 <p>Click <a target="_blank" href="https://drive.google.com/file/d/1pH866L9Z43JVxvhk5wIXaLJUZUNraAvW/view?usp=sharing">here</a> for the list of Singapore Pavillion Exhibitors.</p>
+<p>Click <a target="_blank" href="https://drive.google.com/file/d/1dibXesFREwtIL3mqloeNmydoUpQjO7LV/view?usp=sharing">here</a> for the map of Singapore Pavillion.</p>
 
 <div style="display: flex; flex-wrap: wrap; padding: 10px">
 
@@ -324,7 +325,7 @@ description: ""
 	<div class="sgds-card-booth">
 		<p style="text-transform: uppercase;">
 			<small>
-				<strong>Booth No: 6K1-12A</strong>
+				<strong>Booth No: 6K1-12B</strong>
 			</small>
 		</p>
 	</div>
@@ -2256,7 +2257,7 @@ description: ""
 	<div class="sgds-card-booth">
 		<p style="text-transform: uppercase;">
 			<small>
-				<strong>Booth No: 6K4-02</strong>
+				<strong>Booth No: 6L3-09</strong>
 			</small>
 		</p>
 	</div>
@@ -2564,7 +2565,7 @@ description: ""
 	<div class="sgds-card-booth">
 		<p style="text-transform: uppercase;">
 			<small>
-				<strong>Booth No: 6K1-12B</strong>
+				<strong>Booth No: 6K1-12A</strong>
 			</small>
 		</p>
 	</div>


### PR DESCRIPTION
Updated companies booth no. and add in the SG Pavilion Map in the FHA 2024 event page.